### PR TITLE
[PIE-1385] Update API payload to contain name and version

### DIFF
--- a/Buildkite.TestAnalytics.Common/Buildkite.TestAnalytics.Common.fsproj
+++ b/Buildkite.TestAnalytics.Common/Buildkite.TestAnalytics.Common.fsproj
@@ -14,7 +14,7 @@
     <RepositoryUrl>https://github.com/buildkite/test-collector-dotnet</RepositoryUrl>
     <RespositoryType>git</RespositoryType>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>0.1.1</Version>
+    <Version>0.1.2</Version>
     <IsPackable>true</IsPackable>  </PropertyGroup>
   <ItemGroup>
     <Compile Include="Timing.fs" />

--- a/Buildkite.TestAnalytics.Tests/PayloadTests.fs
+++ b/Buildkite.TestAnalytics.Tests/PayloadTests.fs
@@ -49,6 +49,8 @@ let ``when it detects a Buildkite CI environment it returns an empty payload`` (
     Assert.Equal(runEnv.CommitSha, Some(env.["BUILDKITE_COMMIT"]))
     Assert.Equal(runEnv.Message, Some(env.["BUILDKITE_MESSAGE"]))
     Assert.Equal(runEnv.Url, Some(env.["BUILDKITE_BUILD_URL"]))
+    Assert.Equal(runEnv.Version, "0.1.2.0")
+    Assert.Equal(runEnv.Collector, "dotnet-buildkite-test-collector")
 
 
 [<Fact>]
@@ -83,7 +85,8 @@ let ``when it detects a Github Actions CI environment it returns an empty payloa
     Assert.Equal(runEnv.Branch, Some(env.["GITHUB_REF"]))
     Assert.Equal(runEnv.CommitSha, Some(env.["GITHUB_SHA"]))
     Assert.Equal(runEnv.Message, None)
-
+    Assert.Equal(runEnv.Version, "0.1.2.0")
+    Assert.Equal(runEnv.Collector, "dotnet-buildkite-test-collector")
     Assert.Equal(
         runEnv.Url,
         Some(sprintf "https://github.com/doc-brown/flux-capacitor/actions/run/%s" env.["GITHUB_RUN_ID"])
@@ -115,7 +118,8 @@ let ``when it detects a Circle CI environment it returns an empty payload`` () =
     Assert.Equal(runEnv.CommitSha, Some(env.["CIRCLE_SHA1"]))
     Assert.Equal(runEnv.Message, None)
     Assert.Equal(runEnv.Url, Some "https://example.test/circle")
-
+    Assert.Equal(runEnv.Version, "0.1.2.0")
+    Assert.Equal(runEnv.Collector, "dotnet-buildkite-test-collector")
 [<Fact>]
 let ``when it detects a generic CI environment it returns an empty payload`` () =
     let env = Map [ ("CI", "true") ]
@@ -137,7 +141,8 @@ let ``when it detects a generic CI environment it returns an empty payload`` () 
     Assert.Same(runEnv.CommitSha, None)
     Assert.Same(runEnv.Message, None)
     Assert.Same(runEnv.Url, None)
-
+    Assert.Equal(runEnv.Version, "0.1.2.0")
+    Assert.Equal(runEnv.Collector, "dotnet-buildkite-test-collector")
 let genericEmptyPayload () =
     let env = Map [ ("CI", "true") ]
     Payload.Init(Some(getEnvVarFactory env)).Value

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Useful resources for developing collectors include the [Buildkite Test Analytics
 
 ## 👩‍💻 Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/buildkite/test-collector-python
+Bug reports and pull requests are welcome on GitHub at https://github.com/buildkite/test-collector-dotnet
 
 ## 🚀 Releasing
 


### PR DESCRIPTION
This PR appends collector name and version to the API payload for the test-collector per [PIE-1385](https://linear.app/buildkite/issue/PIE-1385/update-net-collector-api-payload-to-pass-collector-name)