### PR TITLE
PIE-1482 Remove identifier from .net test collector payload

### DIFF
--- a/Buildkite.TestAnalytics.Common/TestData.fs
+++ b/Buildkite.TestAnalytics.Common/TestData.fs
@@ -14,7 +14,6 @@ module TestData =
         { Id: string
           Scope: string option
           Name: string option
-          Identifier: string
           Location: string option
           FileName: string option
           Result: TestResult
@@ -30,8 +29,6 @@ module TestData =
     /// <param name="scope">The parent context under which the test is located -
     /// in our case usually the test class</param>
     /// <param name="name">The human-readable name of the test</param>
-    /// <param name="identifier">A unique identifier for the test. If your test
-    /// runner supports it, use the identifier needed to rerun this test</param>
     /// <param name="location">The file and line number where the test
     /// originates, separated by a colon (:)</param>
     /// <param name="fileName">The file where the test originates</param>
@@ -40,14 +37,12 @@ module TestData =
             id: string,
             scope: string option,
             name: string option,
-            identifier: string,
             location: string option,
             fileName: string option
         ) : Test =
         { Id = id
           Scope = scope
           Name = name
-          Identifier = identifier
           Location = location
           FileName = fileName
           Result = Unknown
@@ -131,7 +126,6 @@ module TestData =
 
         let attrs =
             [ ("id", test.Id :> obj)
-              ("identifier", test.Identifier :> obj)
               ("history", history :> obj) ]
 
         let attrs = if Option.isSome(test.Scope) then

--- a/Buildkite.TestAnalytics.Tests/PayloadTests.fs
+++ b/Buildkite.TestAnalytics.Tests/PayloadTests.fs
@@ -148,7 +148,7 @@ let genericEmptyPayload () =
     Payload.Init(Some(getEnvVarFactory env)).Value
 
 let fakeTest () =
-    TestData.Init(Guid.NewGuid.ToString(), Some("scope"), Some("name"), "identifier", Some "location", Some "fileName")
+    TestData.Init(Guid.NewGuid.ToString(), Some("scope"), Some("name"), Some "location", Some "fileName")
 
 [<Fact>]
 let ``AddTestResult adds a TestResult.Test to the Collection`` () =

--- a/Buildkite.TestAnalytics.Tests/TestDataTests.fs
+++ b/Buildkite.TestAnalytics.Tests/TestDataTests.fs
@@ -7,7 +7,7 @@ open Buildkite.TestAnalytics.Common
 let rand = Random()
 
 let fakeTest () =
-    TestData.Init(Guid.NewGuid.ToString(), Some("scope"), Some("name"), "identifier", Some "location", Some "fileName")
+    TestData.Init(Guid.NewGuid.ToString(), Some("scope"), Some("name"), Some "location", Some "fileName")
 
 let fakeSpan () =
     Tracing.Init(Tracing.Section.Sql, rand.Next(1000), None, None, None)
@@ -17,19 +17,17 @@ let ``Init creates a new test`` () =
     let id = Guid.NewGuid().ToString()
     let scope = "Buildkite.TestAnalytics.Tests"
     let name = "Init creates a new test"
-    let identifier = "Buildkite.TestAnalytics.TestDataTests.Init creates a new test"
     let location = "Buildkite.TestAnalytics.TestDataTests/TestDataTests.fs: line 8"
     let fileName = "TestDataTests.fs"
 
     let testData =
-        TestData.Init(id, Some(scope), Some(name), identifier, Some(location), Some(fileName))
+        TestData.Init(id, Some(scope), Some(name), Some(location), Some(fileName))
 
     let now = Timing.now ()
 
     Assert.Equal(testData.Id, id)
     Assert.Equal(testData.Scope, Some(scope))
     Assert.Equal(testData.Name, Some(name))
-    Assert.Equal(testData.Identifier, identifier)
     Assert.Equal(testData.Location, Some(location))
     Assert.Equal(testData.FileName, Some(fileName))
     Assert.InRange(testData.StartAt, now - 5, now + 5)
@@ -70,7 +68,6 @@ let ``AsJson converts the test into a dict`` () =
     Assert.Equal(json["id"], test.Id)
     Assert.Equal(json["scope"], test.Scope.Value)
     Assert.Equal(json["name"], test.Name.Value)
-    Assert.Equal(json["identifier"], test.Identifier)
     Assert.Equal(json["result"], "unknown")
 
     let test = TestData.Passed(test)

--- a/Buildkite.TestAnalytics.Xunit/Library.fs
+++ b/Buildkite.TestAnalytics.Xunit/Library.fs
@@ -33,11 +33,10 @@ module Sink =
           | :? Sdk.TestStarting as test ->
             let testCollectoinUuid = test.TestCollection.UniqueID.ToString("D")
             let testCaseUuid = testIdToUuid(test.TestCase.UniqueID)
-            let identifier = testCollectoinUuid + ":" + testCaseUuid
             let (location, fileName) = match test.TestCase.SourceInformation with
                                         | null -> (None, None)
                                         | source -> (Some(source.FileName + ":" + source.LineNumber.ToString()), Some(source.FileName))
-            let testData = TestData.Init(testCaseUuid, Some(test.TestCollection.DisplayName), Some(test.Test.DisplayName), identifier, location, fileName)
+            let testData = TestData.Init(testCaseUuid, Some(test.TestCollection.DisplayName), Some(test.Test.DisplayName), location, fileName)
             inFlight <- Map.add test.TestCase.UniqueID testData inFlight
             ()
           | :? Sdk.TestPassed as test ->


### PR DESCRIPTION
Description
We have removed identifier field from DB test table, and we no longer using it in TA.
This PR is for removing identifier from this collector so that they stop sending identifier to TA. [We'll not make a release for this PR](https://linear.app/buildkite/issue/PIE-1427#comment-9ea47561)

Context
Ticket: https://linear.app/buildkite/issue/PIE-1482/remove-identifier-from-net-test-collector-payload
Parent ticket: https://linear.app/buildkite/issue/PIE-1427/remove-identifier-from-test-collector-payloads

Change
Remove identifier from the collector
Fix failing tests caused by the changes