### PR TITLE
Downgrade xunit.runner.visualstudio

### DIFF
--- a/Buildkite.TestAnalytics.Tests/Buildkite.TestAnalytics.Tests.fsproj
+++ b/Buildkite.TestAnalytics.Tests/Buildkite.TestAnalytics.Tests.fsproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
The `xunit.runner.visualstudio` library has been undergoing monotonic upgrades on this repository via dependabot. It appears that test collection is broken in the upgrade to `3.x`.

We are still using version `2.9.x` of `xunit`, and theoretically version `3.x` of the runner is backwards compatible with version `2.x` of `xunit`. However, whilst it runs the tests correctly, it does not hook into the test collection mechanism we have implemented for `2.x`. There are [considerable changes to the custom reporter implementation](https://xunit.net/docs/getting-started/v3/custom-runner-reporter) in version `3.x` and I expect the failure of the hooks is related to this.