### PR TITLE
Fallthrough to empty payload instead of `None`

### DIFF
--- a/Buildkite.TestAnalytics.Common/Api.fs
+++ b/Buildkite.TestAnalytics.Common/Api.fs
@@ -38,7 +38,7 @@ module Api =
 
 
             if response.IsSuccessStatusCode = false then
-                Printf.eprintfn $"Posting analytics results to Buildkite API failed: {response.StatusCode}"
+                Printf.eprintfn $"Posting execution results to Buildkite API failed: {response.StatusCode}"
         }
 
     /// <summary>Submits a payload to the Buildkite API.</summary>
@@ -52,14 +52,17 @@ module Api =
         let _ = client.DefaultRequestHeaders.Authorization <- new AuthenticationHeaderValue("Token", config.apiToken)
         let payloads = Payload.IntoBatches(payload, config.batchSize)
 
-        printf "Sending test analytics data to Buildkite..."
+        if String.IsNullOrWhiteSpace config.apiToken then
+          printf "Skipping sending test execution data to Buildkite, BUILDKITE_ANALYTICS_TOKEN is not set."
+        else
+          printf "Sending test execution data to Buildkite..."
 
-        let task = task {
-            for payload in payloads do
-                let task = submitBatch (payload, client)
-                task.Wait()
-                ()
-        }
-        task.Wait()
+          let task = task {
+              for payload in payloads do
+                  let task = submitBatch (payload, client)
+                  task.Wait()
+                  ()
+          }
+          task.Wait()
 
-        printfn " done."
+          printfn " done."

--- a/Buildkite.TestAnalytics.Common/Payload.fs
+++ b/Buildkite.TestAnalytics.Common/Payload.fs
@@ -87,7 +87,7 @@ module Payload =
                   Version = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString()
                   Collector = "dotnet-buildkite-test-collector" }
             )
-        elif Option.isSome (optionalEnvVar "CI") then
+        else
             Some(
                 { Ci = "generic"
                   Key = Guid.NewGuid().ToString()
@@ -100,8 +100,6 @@ module Payload =
                   Version = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString()
                   Collector = "dotnet-buildkite-test-collector" }
             )
-        else
-            None
 
     /// <summary>(maybe) Initialise a new empty Payload. Attempts to to detect
     /// the CI environment which the code is running in - if said detection

--- a/Buildkite.TestAnalytics.Tests/PayloadTests.fs
+++ b/Buildkite.TestAnalytics.Tests/PayloadTests.fs
@@ -13,12 +13,6 @@ let getEnvVarFactory (env: Map<string, string>) : (string -> string) =
 let rand = Random()
 
 [<Fact>]
-let ``when it cannot detect the environment it returns none`` () =
-    let getEnvVar = getEnvVarFactory (Map [])
-    let payload = Payload.Init(Some getEnvVar)
-    Assert.Same(payload, None)
-
-[<Fact>]
 let ``when it detects a Buildkite CI environment it returns an empty payload`` () =
     let buildId = Guid.NewGuid.ToString()
 
@@ -122,7 +116,7 @@ let ``when it detects a Circle CI environment it returns an empty payload`` () =
     Assert.Equal(runEnv.Collector, "dotnet-buildkite-test-collector")
 [<Fact>]
 let ``when it detects a generic CI environment it returns an empty payload`` () =
-    let env = Map [ ("CI", "true") ]
+    let env = Map []
 
     let payload = Payload.Init(Some(getEnvVarFactory env))
     Assert.True(Option.isSome payload)
@@ -144,7 +138,7 @@ let ``when it detects a generic CI environment it returns an empty payload`` () 
     Assert.Equal(runEnv.Version, "0.1.3.0")
     Assert.Equal(runEnv.Collector, "dotnet-buildkite-test-collector")
 let genericEmptyPayload () =
-    let env = Map [ ("CI", "true") ]
+    let env = Map []
     Payload.Init(Some(getEnvVarFactory env)).Value
 
 let fakeTest () =


### PR DESCRIPTION
`Buildkite.TestAnalytics.Xunit.reporters` emits a
`System.NullReferenceException` when run outside of a CI environment.

We execute the following pseudocode in `Payload.fs`

```
if envVarPresent BUILDKITE_BUILD_ID
  buildkite_payload
elif envVarPresent GITHUB_ACTION
  github_payload
elif envVarPresent CIRCLE_BUILD_NUM
  circleci_payload
elif envVarPresent CI
  generic_payload
else
  None
```

This change merges the 2 final checks into one, so the fallthrough for the method always returns a `generic_payload` rather than `None`, and additionally skips uploading to Test Engine if the authentication token is not set.

## Before

```
$ dotnet test Buildkite.TestAnalytics.Tests
Restore complete (0.4s)
  Buildkite.TestAnalytics.Common succeeded (1.2s) → Buildkite.TestAnalytics.Common/bin/Debug/net9.0/Buildkite.TestAnalytics.Common.dll
  Buildkite.TestAnalytics.Xunit.reporters succeeded (1.3s) → Buildkite.TestAnalytics.Xunit.reporters/bin/Debug/net9.0/Buildkite.TestAnalytics.Xunit.reporters.dll
  Buildkite.TestAnalytics.Tests succeeded (2.1s) → Buildkite.TestAnalytics.Tests/bin/Debug/net9.0/Buildkite.TestAnalytics.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.8.2+699d445a1a (64-bit .NET 9.0.5)
[xUnit.net 00:00:00.04]   Discovering: Buildkite.TestAnalytics.Tests
[xUnit.net 00:00:00.06]   Discovered:  Buildkite.TestAnalytics.Tests
[xUnit.net 00:00:00.06]   Starting:    Buildkite.TestAnalytics.Tests
[xUnit.net 00:00:00.22]   Finished:    Buildkite.TestAnalytics.Tests
  Buildkite.TestAnalytics.Tests test succeeded with 2 warning(s) (0.6s)
    /home/malc/dotnet/sdk/9.0.300/Microsoft.TestPlatform.targets(48,5): warning : 
      [xUnit.net 00:00:00.01] Exception thrown while inspecting type 'Buildkite.TestAnalytics.Xunit.reporters.Sink+Collector' in assembly '/home/malc/scratch/test-collector-dotnet/Buildkite.TestAnalytic
      s.Tests/bin/Debug/net9.0/Buildkite.TestAnalytics.Xunit.reporters.dll':
      System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
       ---> System.NullReferenceException: Object reference not set to an instance of an object.
         at Buildkite.TestAnalytics.Xunit.reporters.Sink.Collector..ctor(FSharpOption`1 payload) in /home/malc/scratch/test-collector-dotnet/Buildkite.TestAnalytics.Xunit.reporters/Library.fs:line 22
         at Buildkite.TestAnalytics.Xunit.reporters.Sink.Collector..ctor() in /home/malc/scratch/test-collector-dotnet/Buildkite.TestAnalytics.Xunit.reporters/Library.fs:line 26
         at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
         at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
         --- End of inner exception stack trace ---
         at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
         at System.Reflection.RuntimeConstructorInfo.Invoke(BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
         at Xunit.RunnerReporterUtility.GetAvailableRunnerReporters(String folder, List`1& messages) in /_/src/xunit.runner.utility/Reporters/RunnerReporterUtility.cs:line 80
    /home/malc/dotnet/sdk/9.0.300/Microsoft.TestPlatform.targets(48,5): warning : 
      [xUnit.net 00:00:00.02] Exception thrown while inspecting type 'Buildkite.TestAnalytics.Xunit.reporters.Sink+Collector' in assembly '/home/malc/scratch/test-collector-dotnet/Buildkite.TestAnalytic
      s.Tests/bin/Debug/net9.0/Buildkite.TestAnalytics.Xunit.reporters.dll':
      System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
       ---> System.NullReferenceException: Object reference not set to an instance of an object.
         at Buildkite.TestAnalytics.Xunit.reporters.Sink.Collector..ctor(FSharpOption`1 payload) in /home/malc/scratch/test-collector-dotnet/Buildkite.TestAnalytics.Xunit.reporters/Library.fs:line 22
         at Buildkite.TestAnalytics.Xunit.reporters.Sink.Collector..ctor() in /home/malc/scratch/test-collector-dotnet/Buildkite.TestAnalytics.Xunit.reporters/Library.fs:line 26
         at InvokeStub_Collector..ctor(Object, Object, IntPtr*)
         at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
         --- End of inner exception stack trace ---
         at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
         at System.Reflection.RuntimeConstructorInfo.Invoke(BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
         at Xunit.RunnerReporterUtility.GetAvailableRunnerReporters(String folder, List`1& messages) in /_/src/xunit.runner.utility/Reporters/RunnerReporterUtility.cs:line 80

Test summary: total: 21, failed: 0, succeeded: 21, skipped: 0, duration: 0.6s
Build succeeded with 2 warning(s) in 6.0s
```

## After

```
$ dotnet test Buildkite.TestAnalytics.Tests
Restore complete (0.4s)
  Buildkite.TestAnalytics.Common succeeded (0.0s) → Buildkite.TestAnalytics.Common/bin/Debug/net9.0/Buildkite.TestAnalytics.Common.dll
  Buildkite.TestAnalytics.Xunit.reporters succeeded (0.2s) → Buildkite.TestAnalytics.Xunit.reporters/bin/Debug/net9.0/Buildkite.TestAnalytics.Xunit.reporters.dll
  Buildkite.TestAnalytics.Tests succeeded (0.1s) → Buildkite.TestAnalytics.Tests/bin/Debug/net9.0/Buildkite.TestAnalytics.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.8.2+699d445a1a (64-bit .NET 9.0.5)
Skipping sending test analytics data to Buildkite, BUILDKITE_ANALYTICS_TOKEN is not set.
  Buildkite.TestAnalytics.Tests test succeeded (0.6s)

Test summary: total: 20, failed: 0, succeeded: 20, skipped: 0, duration: 0.6s
Build succeeded in 1.6s
```