### PR TITLE
Add CODEOWNERS requesting review from @buildkite/validate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @buildkite/validate


### PR DESCRIPTION
Adds a `.github/CODEOWNERS` file so that all PRs (including Dependabot PRs) automatically request a review from @buildkite/validate.

```
* @buildkite/validate
```
